### PR TITLE
fix: optimize build size by 76% + add dual publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ permissions:
   issues: write
   pull-requests: write
   id-token: write
+  packages: write
 
 jobs:
   # Run tests before release
@@ -78,3 +79,36 @@ jobs:
           echo "🎉 Successfully released version ${{ needs.release.outputs.version }}"
           echo "📦 Package: https://www.npmjs.com/package/docling-sdk"
           echo "🏷️ GitHub Release: https://github.com/btwld/docling-sdk/releases/tag/v${{ needs.release.outputs.version }}"
+
+  # Publish to GitHub Package Registry
+  github-packages:
+    needs: release
+    runs-on: ubuntu-latest
+    if: needs.release.outputs.released == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@btwld"
+
+      - run: npm ci
+      - run: npm run build
+
+      # Create scoped package.json for GitHub Packages
+      - name: Setup GitHub Package
+        run: |
+          cp package.json package.json.backup
+          npm pkg set name="@btwld/docling-sdk"
+          npm pkg set publishConfig.registry="https://npm.pkg.github.com"
+
+      - name: Publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Restore original package.json
+      - name: Restore package.json
+        run: mv package.json.backup package.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,16 @@ Releases are **fully automated** using semantic-release:
    BREAKING CHANGE: The API interface has been completely redesigned"
    ```
 
+### Package Ownership
+
+The following npm users have ownership/publishing rights to `docling-sdk`:
+
+- **kauandotnet** (primary maintainer)
+- **leoafarias**
+- **tnramalho**
+
+New owners can be added using: `npm owner add <username> docling-sdk`
+
 ## 🧪 Testing
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Docling Client provides a comprehensive TypeScript interface for:
 npm install docling-sdk
 ```
 
+[![npm version](https://badge.fury.io/js/docling-sdk.svg)](https://www.npmjs.com/package/docling-sdk)
+[![GitHub release](https://img.shields.io/github/release/btwld/docling-sdk.svg)](https://github.com/btwld/docling-sdk/releases)
+[![npm downloads](https://img.shields.io/npm/dm/docling-sdk.svg)](https://www.npmjs.com/package/docling-sdk)
+
 ## Quick Start
 
 ### API Usage (Simple)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/archiver": "^6.0.3",
         "archiver": "^7.0.1",
         "ws": "^8.18.0",
         "zod": "^4.0.15"
@@ -24,6 +23,7 @@
         "@semantic-release/github": "^11.0.4",
         "@semantic-release/npm": "^12.0.2",
         "@semantic-release/release-notes-generator": "^14.0.3",
+        "@types/archiver": "^6.0.3",
         "@types/node": "^22.10.2",
         "@types/ws": "^8.5.13",
         "@vitest/coverage-v8": "^2.1.8",
@@ -3568,6 +3568,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.3.tgz",
       "integrity": "sha512-a6wUll6k3zX6qs5KlxIggs1P1JcYJaTCx2gnlr+f0S1yd2DoaEwoIK10HmBaLnZwWneBz+JBm0dwcZu0zECBcQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/readdir-glob": "*"
@@ -3594,6 +3595,7 @@
       "version": "22.17.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.1.tgz",
       "integrity": "sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3610,6 +3612,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
       "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -11630,6 +11633,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     }
   },
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.mjs",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.mts",
     "README.md",
     "LICENSE"
   ],
@@ -61,6 +64,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/btwld/docling-sdk.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
   "bugs": {
     "url": "https://github.com/btwld/docling-sdk/issues"

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,14 +5,14 @@ export default defineConfig({
   format: ["cjs", "esm"],
   dts: true,
   splitting: false,
-  sourcemap: true,
+  sourcemap: false, // Exclude source maps from build
   clean: true,
-  minify: false,
+  minify: true, // Enable minification for smaller output
   target: "es2022",
   outDir: "dist",
   treeshake: true,
   bundle: true,
-  external: ["ws", "form-data", "cross-spawn"],
+  external: ["ws", "archiver", "zod"],
   esbuildOptions(options) {
     options.banner = {
       js: '"use strict";',


### PR DESCRIPTION
## 📦 Build Size Optimization + Dual Publishing

Massive package size reduction and improved distribution strategy.

### 📈 Size Improvements

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| **Package Size** | 423 kB | **126.7 kB** | **-70%** |
| **Unpacked Size** | 2.3 MB | **560.2 kB** | **-76%** |
| **index.js** | 297 kB | **144 kB** | **-51%** |
| **index.mjs** | 293 kB | **142 kB** | **-52%** |
| **Source Maps** | 1.4 MB | **REMOVED** | **-100%** |

### 🔧 Build Optimizations

- ✅ **Remove source maps** from published package (`sourcemap: false`)
- ✅ **Enable minification** for smaller bundles (`minify: true`)
- ✅ **Exclude source maps** from npm package files
- ✅ **Update externals** to match current dependencies