### PR TITLE
chore: bump version to 1.0.4 for release with TypeScript types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docling-sdk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docling-sdk",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docling-sdk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "TypeScript SDK for Docling - Bridge between Python Docling ecosystem and JavaScript/TypeScript. Supports both CLI and API modes with dual publishing.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
This PR fixes the release pipeline issue where steps were being skipped due to version conflicts.