### PR TITLE
fix(chunk): assign list-typed form fields directly instead of JSON.stringify

### DIFF
--- a/src/services/chunk.ts
+++ b/src/services/chunk.ts
@@ -416,14 +416,14 @@ export class ChunkService {
   private buildFormFields(
     options: ConversionOptions,
     targetType: "inbody" | "zip"
-  ): Record<string, string> {
-    const fields: Record<string, string> = {
+  ): Record<string, unknown> {
+    const fields: Record<string, unknown> = {
       target_type: targetType,
     };
 
     // Add conversion options
     if (options.from_formats) {
-      fields.convert_from_formats = JSON.stringify(options.from_formats);
+      fields.convert_from_formats = options.from_formats;
     }
     if (options.image_export_mode) {
       fields.convert_image_export_mode = options.image_export_mode;
@@ -438,7 +438,7 @@ export class ChunkService {
       fields.convert_ocr_engine = options.ocr_engine;
     }
     if (options.ocr_lang) {
-      fields.convert_ocr_lang = JSON.stringify(options.ocr_lang);
+      fields.convert_ocr_lang = options.ocr_lang;
     }
     if (options.pdf_backend) {
       fields.convert_pdf_backend = options.pdf_backend;
@@ -453,7 +453,7 @@ export class ChunkService {
       fields.convert_pipeline = options.pipeline;
     }
     if (options.page_range) {
-      fields.convert_page_range = JSON.stringify(options.page_range);
+      fields.convert_page_range = options.page_range;
     }
     if (options.document_timeout !== undefined) {
       fields.convert_document_timeout = String(options.document_timeout);

--- a/tests/unit/chunk-service.test.ts
+++ b/tests/unit/chunk-service.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ChunkService } from "../../src/services/chunk";
+import { HttpClient } from "../../src/api";
+import type {
+  ApiClientConfig,
+  ChunkDocumentResponse,
+} from "../../src/types/api";
+
+const mockConfig: ApiClientConfig = {
+  baseUrl: "http://localhost:5001",
+  timeout: 30000,
+};
+
+const capturedFields: Array<Record<string, unknown>> = [];
+
+vi.mock("../../src/api/http", async (importOriginal) => {
+  const mod: any = await importOriginal();
+  return {
+    HttpClient: class extends mod.HttpClient {
+      async streamUpload(
+        _endpoint: string,
+        _files: any,
+        fields: Record<string, unknown>
+      ) {
+        capturedFields.push(fields);
+        return {
+          data: {
+            documents: [],
+            chunks: [],
+            processing_time: 1,
+          } satisfies ChunkDocumentResponse,
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "application/json" },
+        };
+      }
+    },
+  };
+});
+
+describe("ChunkService.buildFormFields", () => {
+  let http: HttpClient;
+  let service: ChunkService;
+
+  beforeEach(() => {
+    capturedFields.length = 0;
+    http = new HttpClient(mockConfig);
+    service = new ChunkService(http);
+  });
+
+  it("passes list-typed conversion options as arrays (not JSON strings) to streamUpload", async () => {
+    await service.chunkHybridSync(Buffer.from("pdf"), "example.pdf", {
+      from_formats: ["pdf", "docx"],
+      ocr_lang: ["en", "fr"],
+      page_range: [1, 2],
+    });
+
+    expect(capturedFields).toHaveLength(1);
+    const fields = capturedFields[0];
+
+    expect(fields.convert_from_formats).toEqual(["pdf", "docx"]);
+    expect(fields.convert_ocr_lang).toEqual(["en", "fr"]);
+    expect(fields.convert_page_range).toEqual([1, 2]);
+
+    // Guard against regression to JSON.stringify.
+    expect(typeof fields.convert_from_formats).not.toBe("string");
+    expect(typeof fields.convert_ocr_lang).not.toBe("string");
+    expect(typeof fields.convert_page_range).not.toBe("string");
+  });
+});


### PR DESCRIPTION
## Problem

`ChunkService.buildFormFields` JSON-stringifies three list-typed conversion options into single multipart form-field values:

- `src/services/chunk.ts:426` — `from_formats`
- `src/services/chunk.ts:441` — `ocr_lang`
- `src/services/chunk.ts:456` — `page_range`

docling-serve (≥ 1.5) expects these as repeated multi-value form fields, so any chunk request that sets, e.g., `from_formats: ['pdf']` gets a Pydantic 422.

## Repro

```ts
import { DoclingAPIClient } from "docling-sdk";

const client = new DoclingAPIClient({ baseUrl: "http://localhost:5001" });
await client.chunking.chunkHybridSync(fileBuffer, "example.pdf", {
  from_formats: ["pdf"],   // → HTTP 422 from Pydantic
});
```

## Fix

Mirror the convert path's pattern (`src/services/file.ts:508`):

- Widen `buildFormFields` (a `private` method, no API surface change) from `Record<string, string>` to `Record<string, unknown>`.
- Assign `options.from_formats` / `options.ocr_lang` / `options.page_range` directly to `fields.*` instead of `JSON.stringify(...)`.

The platform multipart encoder at `src/platform/http.ts` already does:

```ts
if (Array.isArray(value)) {
  for (const item of value) {
    formData.append(key, String(item));
  }
}
```

…so the `page_range: [number, number]` tuple serializes correctly via `String(item)` without needing explicit help from the caller.

## Test

Adds `tests/unit/chunk-service.test.ts` (mirrors the existing `file-service.test.ts` pattern — `vi.mock('../../src/api/http', ...)` intercepts `streamUpload` and captures the `fields` argument). The test calls `chunkHybridSync` with all three list-typed options set and asserts they arrive at `streamUpload` as arrays, not JSON strings.

All 154 existing unit tests still pass; `npm run typecheck`, `npm run build`, and `npm run check` are green.

## Context

- This is the chunk-path companion to the convert path already covered by `file.ts:508`. The two paths use different form-field name prefixes (`convert_*` on chunk vs. unprefixed on convert) but the multi-value contract on the wire is the same.
- Schema-shape context (separate, upstream of docling-serve): docling-project/docling-serve#486, #489.
- Spec for multi-value form fields: https://deepwiki.com/docling-project/docling-serve/4-api-reference

Closes #74.
